### PR TITLE
Improve spacing on subnavigation links

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -550,6 +550,13 @@ header {
   }
 }
 
+.subnavigation ul li {
+
+  @include breakpoint(medium) {
+    margin-right: $line-height / 2;
+  }
+}
+
 .additional-content .filter-subnav {
   background: $light;
 }


### PR DESCRIPTION
## Objectives

Improve spacing on subnavigation links to prevent it the layout resize to two lines.

## Visual Changes

### Before
<img width="1016" alt="before" src="https://user-images.githubusercontent.com/631897/99944052-8f61b900-2d72-11eb-8304-16dd72d23601.png">

### After
<img width="1008" alt="after" src="https://user-images.githubusercontent.com/631897/99944061-925ca980-2d72-11eb-8041-e63f0402382d.png">
