### PR TITLE
Backport CONSUL

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1471,8 +1471,16 @@ footer {
   background: #fff;
   border: 0;
 
+  .comment {
+    position: relative;
+  }
+
   .comment-input {
     border-bottom: 0;
+  }
+
+  .comment-footer {
+    min-height: $line-height * 4;
   }
 }
 
@@ -1491,7 +1499,6 @@ footer {
 
 .draft-panels .comments-on .calc-comments .comments-box-container {
   margin-top: $line-height * 2;
-  position: initial;
 }
 
 .comments-box-container .comment-meta .comment-votes {

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -8,7 +8,7 @@ class Admin::BudgetsController < Admin::BaseController
   has_filters %w[all open finished], only: :index
 
   before_action :load_budget, except: [:index, :new, :create]
-  before_action :load_staff, only: [:new, :edit]
+  before_action :load_staff, only: [:new, :show, :edit]
   before_action :set_budget_mode, only: [:new, :create, :switch_group]
   load_and_authorize_resource
 

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -153,8 +153,12 @@ class Budget < ApplicationRecord
     current_phase&.balloting_or_later?
   end
 
+  def single_group?
+    groups.count == 1
+  end
+
   def single_heading?
-    groups.count == 1 && headings.count == 1
+    single_group? && headings.count == 1
   end
 
   def enabled_phases_amount

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -30,10 +30,6 @@ class Budget
       all.sort_by(&:name)
     end
 
-    def single_heading_group?
-      headings.count == 1
-    end
-
     private
 
       def generate_slug?

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -48,7 +48,7 @@ class Budget
     end
 
     def name_scoped_by_group
-      group.single_heading_group? ? name : "#{group.name}: #{name}"
+      budget.single_group? ? name : "#{group.name}: #{name}"
     end
 
     def can_be_deleted?

--- a/app/views/budgets/_budget.html.erb
+++ b/app/views/budgets/_budget.html.erb
@@ -24,7 +24,7 @@
 <div class="row budget-subheader">
   <div class="small-12 medium-8 column padding">
     <span class="current-phase"><strong><%= t("budgets.show.phase") %></strong></span>
-    <h2><%= t("budgets.phase.#{budget.phase}") %></h2>
+    <h2><%= budget_phase_name(budget.current_phase) %></h2>
   </div>
 
   <div class="small-12 medium-4 column">

--- a/spec/system/admin/budget_investments_spec.rb
+++ b/spec/system/admin/budget_investments_spec.rb
@@ -127,7 +127,7 @@ describe "Admin budget investments" do
       expect(page).to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
-      select "Central Park", from: "heading_id"
+      select "Parks: Central Park", from: "heading_id"
       click_button "Filter"
 
       expect(page).not_to have_link("Realocate visitors")
@@ -1066,7 +1066,7 @@ describe "Admin budget investments" do
 
       fill_in "Title", with: "Potatoes"
       fill_in "Description", with: "Carrots"
-      select "#{budget_investment.group.name}: Barbate", from: "budget_investment[heading_id]"
+      select "Barbate", from: "budget_investment[heading_id]"
       uncheck "budget_investment_incompatible"
       check "budget_investment_selected"
 

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -612,6 +612,29 @@ describe "Admin budgets" do
       expect(page).to have_current_path admin_budget_path(budget)
     end
 
+    scenario "Select administrators and valuators", :js do
+      admin = Administrator.first
+      valuator = create(:valuator)
+
+      budget = create(:budget)
+
+      visit edit_admin_budget_path(budget)
+
+      click_link "Select administrators"
+      check admin.name
+
+      click_link "Select valuators"
+      check valuator.name
+
+      click_button "Update Budget"
+
+      click_link "1 administrator selected"
+      expect(find_field(admin.name)).to be_checked
+
+      click_link "1 valuator selected"
+      expect(find_field(valuator.name)).to be_checked
+    end
+
     scenario "Deselect all selected staff", :js do
       admin = Administrator.first
       valuator = create(:valuator)

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -65,6 +65,19 @@ describe "Budgets" do
       expect(page).not_to have_content("#finished_budgets")
     end
 
+    scenario "Show custom phase name on subheader" do
+      budget.update!(phase: "informing")
+      budget.phases.informing.update!(name: "Custom name for informing phase")
+
+      visit budgets_path
+
+      within(".budget-subheader") do
+        expect(page).to have_content("Actual phase")
+        expect(page).to have_content("Custom name for informing phase")
+        expect(page).not_to have_content("Information")
+      end
+    end
+
     scenario "Show finished budgets list" do
       finished_budget_1 = create(:budget, :finished)
       finished_budget_2 = create(:budget, :finished)

--- a/spec/system/budgets/investments_spec.rb
+++ b/spec/system/budgets/investments_spec.rb
@@ -916,8 +916,23 @@ describe "Budget Investments" do
       expect(page).to have_content "Build a skyscraper"
     end
 
+    scenario "Create with single group and multiple headings" do
+      budget = create(:budget)
+      group = create(:budget_group, name: "New group", budget: budget)
+      create(:budget_heading, budget: budget, group: group, name: "Culture")
+      create(:budget_heading, budget: budget, group: group, name: "Environment")
+
+      login_as(author)
+
+      visit new_budget_investment_path(budget)
+
+      expect(page).not_to have_content "New group"
+      select_options = find("#budget_investment_heading_id").all("option").map(&:text)
+      expect(select_options).to eq ["", "Culture", "Environment"]
+    end
+
     scenario "Create with multiple headings" do
-      heading2 = create(:budget_heading, budget: budget)
+      heading2 = create(:budget_heading, budget: budget, group: group)
       heading3 = create(:budget_heading, budget: budget)
       login_as(author)
 
@@ -931,7 +946,7 @@ describe "Budget Investments" do
         expect(page).to have_selector("option[value='#{heading3.id}']")
       end
 
-      select  heading2.name, from: "budget_investment_heading_id"
+      select "#{group.name}: #{heading2.name}", from: "budget_investment_heading_id"
       fill_in "Title", with: "Build a skyscraper"
       fill_in "Description", with: "I want to live in a high tower over the clouds"
       fill_in "budget_investment_location", with: "City center"
@@ -1084,7 +1099,7 @@ describe "Budget Investments" do
 
       select_options = find("#budget_investment_heading_id").all("option").map(&:text)
       expect(select_options).to eq ["",
-                                    "Toda la ciudad",
+                                    "Toda la ciudad: Toda la ciudad",
                                     "Health: More health professionals",
                                     "Health: More hospitals"]
     end

--- a/spec/system/management/budget_investments_spec.rb
+++ b/spec/system/management/budget_investments_spec.rb
@@ -386,7 +386,7 @@ describe "Budget Investments" do
         expect(page).to have_content(low_investment.title)
       end
 
-      select "Whole city: District Nine", from: "heading_id"
+      select "District Nine", from: "heading_id"
       click_button("Search")
 
       within "#budget-investments" do


### PR DESCRIPTION
## References

This is a backport of:

- Hide group name only on budgets with one group https://github.com/StemvanGroningen/consul/pull/81
- Show custom phase name on budget subheader https://github.com/StemvanGroningen/consul/pull/82
- Correct load administrator and valuator list for budgets https://github.com/StemvanGroningen/consul/pull/83
- Fix legislation comments box container position https://github.com/StemvanGroningen/consul/pull/88

## Notes

Backport these commits to [CONSUL](https://github.com/consul/consul/).